### PR TITLE
観測データの分散行列Rを単位行列になっていた。観測精度に応じた行列に修正

### DIFF
--- a/foamdapy/foamdapy.py
+++ b/foamdapy/foamdapy.py
@@ -12,6 +12,7 @@ import glob
 from .tools import cell_distance
 from .tools import localizemat
 from .tools import letkf_update
+from .tools import createRdiag_from_xf
 from .foamer import OFCase
 
 
@@ -103,13 +104,16 @@ class EnSim:
         case = self.obs_case
         self.y0 = case.getValues(time_name, self.y_names, self.obs_cells)
 
+    def set_R_diag(self):
+        self.R_diag = createRdiag_from_xf(self.xf, self.n_cells, self.y_indexes)
+
     def letkf_update(self):
         xf = self.xf
         H = self.H
         y_indexes = self.y_indexes
         y0 = self.y0
         lmat = localizemat(self.mat_d, 0.1)
-        self.xa = letkf_update(xf, H, y0, y_indexes, lmat, self.num_cpus)
+        self.xa = letkf_update(xf, H, y0, self.R_diag, y_indexes, lmat, self.num_cpus)
 
     def limit_val_in_xa(self, slice_st: int, slice_end: int, min_val, max_val):
         xa = self.xa

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -3,6 +3,30 @@ from scipy.sparse import coo_matrix
 
 from foamdapy.tools import decimal_normalize
 from foamdapy.tools import letkf_update
+from foamdapy.tools import createRdiag_from_xf
+
+
+def test_createRdiag_from_xf():
+    np.random.seed(0)
+    num_ensenble = 20
+    x1 = (-6, 8)
+    x2 = (0, 8)
+    xf = np.stack(
+        [
+            np.array([x1[0]] * num_ensenble),
+            np.array([x1[0] + x1[1]] * num_ensenble),
+            np.array([x1[1]] * num_ensenble),
+            np.array([x2[0]] * num_ensenble),
+            np.array([x2[0] + x2[1]] * num_ensenble),
+            np.array([x2[1]] * num_ensenble),
+        ],
+        axis=1,
+    )
+    n_cells = 3  # 3セル x 2変数
+    obs_indexes = [0, 4]  # 1変数目:0,1,2、　2変数目:3,4,5
+    res = createRdiag_from_xf(xf, n_cells, obs_indexes)
+    assert res[0] == ((x1[1] - x1[0]) * 0.01 / 2.0) ** 2
+    assert res[1] == ((x2[1] - x2[0]) * 0.01 / 2.0) ** 2
 
 
 def test_decimal_normalize():
@@ -29,17 +53,18 @@ def test_letkf_update():
     t0 = xf * 2.0
     y0 = t0[:, -num_obs:].mean(axis=0)
     y_indexes = np.array([1, 2])
+    R_diag = createRdiag_from_xf(xf, 3, y_indexes)
     lmat = np.full((3, 3), 1.0)
     num_cpu = 1
-    xa_loop = letkf_update(xf, Hlil, y0, y_indexes, lmat, num_cpu)
+    xa_loop = letkf_update(xf, Hlil, y0, R_diag, y_indexes, lmat, num_cpu)
     xa1 = xa_loop.copy()
-    for i in range(200):
-        xa_loop = letkf_update(xa_loop, Hlil, y0, y_indexes, lmat, num_cpu)
+    for i in range(10):
+        xa_loop = letkf_update(xa_loop, Hlil, y0, R_diag, y_indexes, lmat, num_cpu)
 
     # test of converges to observed value
-    assert (np.round(xa_loop.mean(axis=0)[-num_obs:], 1) == np.round(y0, 1)).all()
+    assert (np.round(xa_loop.mean(axis=0)[-num_obs:], 3) == np.round(y0, 3)).all()
 
     # parallel test
     num_cpu = 2
-    xa2 = letkf_update(xf, Hlil, y0, y_indexes, lmat, num_cpu)
+    xa2 = letkf_update(xf, Hlil, y0, R_diag, y_indexes, lmat, num_cpu)
     assert (np.round(xa1.mean(axis=0), 9) == np.round(xa2.mean(axis=0), 9)).all()


### PR DESCRIPTION
観測データの誤差分散行列が単位行列になっていた。
・予報変数の測定レンジから、誤差分散行列を設定するメソッドを実装。(createRdiag_from_xf)
・invRの計算の時に、誤差分散行列を資料（invR_nonZero)
・test_createRdiag_from_xfを実装
・letkf_updateが精度向上。test_letkf_updateの閾値up